### PR TITLE
A couple of new options for bcat

### DIFF
--- a/bin/bcat
+++ b/bin/bcat
@@ -1,5 +1,6 @@
 #!/usr/bin/env ruby
 #/ Usage: bcat [-htp] [-a] [-b <browser>] [-T <title>] [<file>]...
+#/        bcat [-htp] [-a] [-b <browser>] [-T <title>] -c command...
 #/        btee <options> [<file>]...
 #/ Pipe to browser utility. Read standard input, possibly one or more <file>s,
 #/ and write concatenated / formatted output to browser. When invoked as btee,
@@ -15,7 +16,8 @@
 #/   -t, --text                 input is unencoded text
 #/
 #/ Misc options:
-#/   -p, --persist              serve files until interrupted, allowing reload
+#/   -c, --command              read the standard output of command
+#/   -p, --persist              serve until interrupted, allowing reload
 #/   -d, --debug                enable verbose debug logging on stderr
 require 'optparse'
 

--- a/bin/bcat
+++ b/bin/bcat
@@ -25,6 +25,7 @@ options = {
   :title   => nil,
   :browser => (ENV['BCAT_BROWSER'].to_s.size > 0 ? ENV['BCAT_BROWSER'] : 'default'),
   :ansi    => false,
+  :persist => false,
   :debug   => false,
   :tee     => !!($0 =~ /tee$/)
 }
@@ -38,6 +39,7 @@ ARGV.options do |argv|
   argv.on('-b', '--browser=v') { |app|  options[:browser] = app }
   argv.on('-T', '--title=v')   { |text| options[:title] = text }
   argv.on('-a', '--ansi')      { options[:ansi] = true }
+  argv.on('-p', '--persist')   { options[:persist] = true }
   argv.on('-d', '--debug')     { options[:debug] = true }
   argv.on('--host=v')          { |addr| options[:Host] = addr }
   argv.on('--port=v')          { |port| options[:Port] = port.to_i }

--- a/bin/bcat
+++ b/bin/bcat
@@ -1,5 +1,5 @@
 #!/usr/bin/env ruby
-#/ Usage: bcat [-ht] [-a] [-b <browser>] [-T <title>] [<file>]...
+#/ Usage: bcat [-htp] [-a] [-b <browser>] [-T <title>] [<file>]...
 #/        btee <options> [<file>]...
 #/ Pipe to browser utility. Read standard input, possibly one or more <file>s,
 #/ and write concatenated / formatted output to browser. When invoked as btee,
@@ -15,7 +15,8 @@
 #/   -t, --text                 input is unencoded text
 #/
 #/ Misc options:
-#/   -d, --debug          enable verbose debug logging on stderr
+#/   -p, --persist              serve files until interrupted, allowing reload
+#/   -d, --debug                enable verbose debug logging on stderr
 require 'optparse'
 
 options = {

--- a/bin/bcat
+++ b/bin/bcat
@@ -27,6 +27,7 @@ options = {
   :browser => (ENV['BCAT_BROWSER'].to_s.size > 0 ? ENV['BCAT_BROWSER'] : 'default'),
   :ansi    => false,
   :persist => false,
+  :command => false,
   :debug   => false,
   :tee     => !!($0 =~ /tee$/)
 }
@@ -41,6 +42,7 @@ ARGV.options do |argv|
   argv.on('-T', '--title=v')   { |text| options[:title] = text }
   argv.on('-a', '--ansi')      { options[:ansi] = true }
   argv.on('-p', '--persist')   { options[:persist] = true }
+  argv.on('-c', '--command')   { options[:command] = true }
   argv.on('-d', '--debug')     { options[:debug] = true }
   argv.on('--host=v')          { |addr| options[:Host] = addr }
   argv.on('--port=v')          { |port| options[:Port] = port.to_i }

--- a/lib/bcat.rb
+++ b/lib/bcat.rb
@@ -11,9 +11,9 @@ class Bcat
 
   attr_reader :format
 
-  def initialize(files=[], config={})
+  def initialize(args=[], config={})
     @config = {:Host => '127.0.0.1', :Port => 8091}.merge(config)
-    @reader = Bcat::Reader.new(files)
+    @reader = Bcat::Reader.new(@config[:command], args)
     @format = @config[:format]
   end
 

--- a/lib/bcat.rb
+++ b/lib/bcat.rb
@@ -39,6 +39,8 @@ class Bcat
   end
 
   def assemble
+    @reader.open
+
     @format = @reader.sniff if @format.nil?
 
     @filter = @reader
@@ -103,8 +105,10 @@ class Bcat
   end
 
   def close
-    notice "closing with interrupt"
-    raise Interrupt, "connection closed"
+    unless @config[:persist]
+      notice "closing with interrupt"
+      raise Interrupt, "connection closed"
+    end
   end
 
   def notice(message)

--- a/lib/bcat/reader.rb
+++ b/lib/bcat/reader.rb
@@ -4,23 +4,32 @@ class Bcat
   # ARGF style multi-file streaming interface. Input is read with IO#readpartial
   # to avoid buffering.
   class Reader
-    attr_reader :files
+    attr_reader :is_command
+    attr_reader :args
     attr_reader :fds
 
-    def initialize(files=[])
-      @files = files
+    def initialize(is_command, args=[])
+      @is_command = is_command
+      @args = args
     end
 
     def open
-      @fds =
-        files.map do |f|
-          if f == '-'
-            $stdin
-          else
-            File.open(f, 'rb')
-          end
-        end
+      @fds = is_command ? open_command : open_files
       @buf = []
+    end
+
+    def open_command
+      [IO.popen(args.join(' '), 'rb')]
+    end
+
+    def open_files
+      args.map do |f|
+        if f == '-'
+          $stdin
+        else
+          File.open(f, 'rb')
+        end
+      end
     end
 
     def each

--- a/lib/bcat/reader.rb
+++ b/lib/bcat/reader.rb
@@ -9,6 +9,9 @@ class Bcat
 
     def initialize(files=[])
       @files = files
+    end
+
+    def open
       @fds =
         files.map do |f|
           if f == '-'

--- a/lib/bcat/reader.rb
+++ b/lib/bcat/reader.rb
@@ -26,6 +26,7 @@ class Bcat
     def each
       yield @buf.shift while @buf.any?
       while fd = fds.first
+        fds.shift and next if fd.closed?
         fd.sync = true
         begin
           while buf = fd.readpartial(4096)

--- a/man/bcat.1.ronn
+++ b/man/bcat.1.ronn
@@ -4,6 +4,7 @@ bcat(1) -- browser cat
 ## SYNOPSIS
 
 `bcat` [-htapd] [<file>...]<br>
+`bcat` [-htapd] -c <command>...<br>
 `btee` [-htad] [<file>...]
 
 ## DESCRIPTION
@@ -53,10 +54,15 @@ with these options:
 
 Miscellaneous options:
 
+  * `-c`, `--command`:
+    Interpret the remaining options as a command to be run whose output should
+    be piped into the web browser.
+
   * `-p`, `--persist`:
     Have `bcat` serve requests until it is interrupted. Reloading the page
-    in the browser will cause `bcat` to re-read the files. Standard input
-    can only be read once and will produce no content on subsequent requests.
+    in the browser will cause `bcat` to re-read the files (or re-run the command
+    if used with the `--command` option). Standard input can only be read once
+    and will produce no content on subsequent requests.
 
   * `-d`, `--debug`:
     Turn on verbose debug logging to standard error. Include this output when
@@ -96,6 +102,10 @@ For previewing HTML:
     erb -T - template.erb |bcat
     mustache < template.mustache |bcat
     pygmentize -Ofull,style=colorful -f html main.c |bcat
+
+Regenerate the content each time the page is reloaded:
+
+    bcat -pc markdown README.md
 
 As a simple man pager:
 

--- a/man/bcat.1.ronn
+++ b/man/bcat.1.ronn
@@ -3,7 +3,7 @@ bcat(1) -- browser cat
 
 ## SYNOPSIS
 
-`bcat` [-htad] [<file>...]<br>
+`bcat` [-htapd] [<file>...]<br>
 `btee` [-htad] [<file>...]
 
 ## DESCRIPTION
@@ -46,12 +46,17 @@ with these options:
     entire output is wrapped in a `<pre>`.
 
   * `-h`, `--html`:
-    The input is already HTML encoded. Under this mode, bcat passes input
+    The input is already HTML encoded. Under this mode, `bcat` passes input
     through to the browser mostly unmodified. The input may be a full HTML
     document, or it may be an HTML fragment. `bcat` outputs `<html>`, `<head>`,
     and `<body>` elements even if they are not included in the input.
 
 Miscellaneous options:
+
+  * `-p`, `--persist`:
+    Have `bcat` serve requests until it is interrupted. Reloading the page
+    in the browser will cause `bcat` to re-read the files. Standard input
+    can only be read once and will produce no content on subsequent requests.
 
   * `-d`, `--debug`:
     Turn on verbose debug logging to standard error. Include this output when


### PR DESCRIPTION
I've added a couple of new options to bcat that I think are generally useful. There's a --persist option that keeps the built-in web server running meaning you can reload the page in the browser and have the files re-read. There's also a --command option that reads the output of a command instead of reading files. They can be used independently, but are most useful together: you can do something like

```
bcat -pc rdiscount README.md
```

to have bcat run rdiscount to convert the file into HTML. Then, when you've edited README.md a bit you can reload in the browser to have it converted again. I think this makes the the editing workflow more streamlined.

-Mark.
