### PR TITLE
Fix BCAT_COMMAND

### DIFF
--- a/lib/bcat/browser.rb
+++ b/lib/bcat/browser.rb
@@ -43,7 +43,6 @@ class Bcat
     end
 
     def open(url)
-      command = browser_command
       fork do
         $stdin.close
         exec "#{command} '#{shell_quote(url)}'"


### PR DESCRIPTION
somebody thought it was odd that uzbl was listed on the website but can't actually be used with bcat, this is a quick fix.
