### PR TITLE
Implement xterm-256 colors

### DIFF
--- a/test/test_bcat_ansi.rb
+++ b/test/test_bcat_ansi.rb
@@ -118,4 +118,10 @@ class ANSITest < Test::Unit::TestCase
     expect = "oops forgot the 'm'"
     assert_equal expect, Bcat::ANSI.new(text).to_html
   end
+
+  test "xterm-256" do
+    text = "\x1b[38;5;196mhello"
+    expect = "<span style='color:#ff0000'>hello</span>"
+    assert_equal expect, Bcat::ANSI.new(text).to_html
+  end
 end


### PR DESCRIPTION
This makes lolcat happy:

```
ruby -h | lolcat -f | bcat
```
